### PR TITLE
Fix Xcode 15 pod repo push fails with too low deployment target

### DIFF
--- a/lib/cocoapods/installer/analyzer.rb
+++ b/lib/cocoapods/installer/analyzer.rb
@@ -865,7 +865,7 @@ module Pod
           Version.new(library_spec.deployment_target(platform_name) || default)
         end.max
         if platform_name == :ios && build_type.framework?
-          minimum = Version.new('8.0')
+          minimum = Version.new('12.0')
           deployment_target = [deployment_target, minimum].max
         end
         Platform.new(platform_name, deployment_target)

--- a/lib/cocoapods/validator.rb
+++ b/lib/cocoapods/validator.rb
@@ -566,7 +566,7 @@ module Pod
     def deployment_target
       deployment_target = spec.subspec_by_name(subspec_name).deployment_target(consumer.platform_name)
       if consumer.platform_name == :ios && use_frameworks
-        minimum = Version.new('8.0')
+        minimum = Version.new('12.0')
         deployment_target = [Version.new(deployment_target), minimum].max.to_s
       end
       deployment_target


### PR DESCRIPTION
Updated minimum ios deployment target in validator and analyzer from `8.0` to `12.0`

Resolves #12033